### PR TITLE
Fix Zoho token expiry calculation

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -45,7 +45,9 @@ const formatTokensForStore = (
   if (tokenData.refresh_token) refreshToken = tokenData.refresh_token;
   const tokenStore: ITokenStore = {
     accessToken: tokenData.access_token,
-    expiry: new Date().getTime() + tokenData.expires_in,
+    // Zoho returns the expiry time in seconds but Date.now() is in
+    // milliseconds. Convert the value to milliseconds before adding.
+    expiry: new Date().getTime() + tokenData.expires_in * 1000,
     refreshToken
   };
   return tokenStore;


### PR DESCRIPTION
## Summary
- correct calculation of OAuth token expiration time

## Testing
- `yarn test` *(fails: package not present in lockfile)*


------
https://chatgpt.com/codex/tasks/task_e_68426619d348832b82bdf69f4e35d793