### PR TITLE
Add minimal Jest test setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
   },
   "scripts": {
     "prepublish": "rmdir /S /Q lib && tsc",
-    "test": "jest --watch"
+    "test": "jest"
   }
 }

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,21 @@
+import utils from '../src/utils';
+
+describe('utils.replaceSpaces', () => {
+  test('replaces spaces with underscores and reverts', () => {
+    const input = [{ 'My Field': 'value' }];
+    const withUnderscore = utils.replaceSpaces(input);
+    expect(withUnderscore[0]).toHaveProperty('My_Field', 'value');
+
+    const reverted = utils.replaceSpaces(withUnderscore, true);
+    expect(reverted[0]).toHaveProperty('My Field', 'value');
+  });
+});
+
+// Basic test for getQueryFields
+
+describe('utils.getQueryFields', () => {
+  test('returns query string with replaced spaces', () => {
+    const result = utils.getQueryFields(['Field One', 'SecondField']);
+    expect(result).toBe('?fields=Field_One,SecondField');
+  });
+});


### PR DESCRIPTION
## Summary
- add initial utils tests
- update `npm test` script to run jest in CI friendly mode

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684267618c74832ba16818c1232d6691