### PR TITLE
Fix field query prefix when base URL has query

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ class Zoho {
     try {
       const token = await utils.getToken(this.config)
       const response = await axios.get(
-        `${url}${utils.getQueryFields(columns)}`,
+        `${url}${utils.getQueryFields(columns, url.includes('?'))}`,
         {
           headers: { Authorization: `Zoho-oauthtoken ${token}` }
         }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -80,10 +80,14 @@ const replaceSpaces = (
   return mapped;
 };
 
-const getQueryFields = (columns: Array<string>): string => {
+const getQueryFields = (
+  columns: Array<string>,
+  hasQuery: boolean = false
+): string => {
   if (!columns.length) return "";
   const columnsWithoutSpaces = columns.map(c => replaceSpace(c));
-  return `?fields=${columnsWithoutSpaces.join(",")}`;
+  const prefix = hasQuery ? "&" : "?";
+  return `${prefix}fields=${columnsWithoutSpaces.join(",")}`;
 };
 
 const getTokenFromGrantToken = async (config: IConfig): Promise<string> => {

--- a/test/url-generation.test.ts
+++ b/test/url-generation.test.ts
@@ -1,0 +1,18 @@
+import utils from '../src/utils';
+import { getZohoUrl } from '../src/utils/urlGenerators';
+
+describe('URL generation', () => {
+  const config = { location: 'com' } as any;
+
+  test('fields query is prefixed with ? when base url has none', () => {
+    const base = getZohoUrl(config, 'deals');
+    const url = `${base}${utils.getQueryFields(['Name'], base.includes('?'))}`;
+    expect(url).toBe('https://www.zohoapis.com/crm/v2/deals?fields=Name');
+  });
+
+  test('fields query is prefixed with & when base url already has query', () => {
+    const base = getZohoUrl(config, 'users');
+    const url = `${base}${utils.getQueryFields(['Full Name'], base.includes('?'))}`;
+    expect(url).toBe('https://www.zohoapis.com/crm/v2/users?type=ActiveUsers&fields=Full_Name');
+  });
+});


### PR DESCRIPTION
## Summary
- adjust `getQueryFields` to handle existing queries
- use new parameter from `get`
- add Jest tests covering modules with and without query parameters

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6842675ca4d8832ba6ea6639e24cdcd8